### PR TITLE
Removes duplicated statement around required input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,9 +38,9 @@ inputs:
     required: false
   num-uniform-shards:
     description: 'Set to a number larger than 1 to randomly split your tests into multiple shards.'
+    required: false
   num-shards:
     description: 'Set to a number larger than 1 to split your tests into even shards based on test count.'
-    required: false
     required: false
   directories-to-pull:
     description: 'Directories to pull from device and store in <outputs-dir>, one per line'


### PR DESCRIPTION
It seems [this commit introduced a bug](https://github.com/emulator-wtf/run-tests/commit/cf0b6ba2458ff91b7248f7cade4476ee19ecd782) in the GHA, since the `required` statement becames duplicated for `num-shards` input and at the same time missing for `num-uniform-shards` input.

- [Example of Workflow run](https://github.com/dotanuki-labs/norris/runs/3979305474?check_suite_focus=true) reproducing the bug
- [Example of Workflow run](https://github.com/dotanuki-labs/norris/runs/3979589515?check_suite_focus=true) with version `0.0.2` (the commit mentioned is the [only one between 0.0.2 and 0.0.3](https://github.com/emulator-wtf/run-tests/compare/v0.0.2...v0.0.3))

This PR fixes this silly bug. 🙂