### PR TITLE
chore: bump subtasks to latest versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,11 +118,11 @@ runs:
   using: composite
   steps:
     - name: Setup ew-cli
-      uses: emulator-wtf/setup-ew-cli@v0.9.10
+      uses: emulator-wtf/setup-ew-cli@v0.9.11
       with:
         version: ${{ inputs.version }}
     - name: Run instrumented tests
-      uses: emulator-wtf/invoke@v0.9.7
+      uses: emulator-wtf/invoke@v0.9.8
       with:
         # Authentication
         api-token: ${{ inputs.api-token }}


### PR DESCRIPTION
- bumps `emulator-wtf/setup-ew-cli` to `v0.9.11`
- bumps `emulator-wtf/invoke` to `v0.9.8`