### PR TITLE
Fix zizmor warnings and apply yamlint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: emulator-wtf/configure-credentials@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: emulator-wtf/configure-credentials@d0d840f8d9e2920e284788fcfa32f0a1eed95bf0 # v1.0.0
       with:
         oidc-configuration-id: ${{ vars.EW_OIDC_ID }}
     - run: curl -o minimal.apk -sS https://maven.emulator.wtf/releases/wtf/emulator/minimal/0.0.2/minimal-0.0.2.apk 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
+---
 name: Test
 permissions:
   contents: read
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
   push:
     branches:
@@ -15,16 +16,20 @@ jobs:
       # required for emulator-wtf/configure-credentials to mint an OIDC token
       id-token: write
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
-        persist-credentials: false
-    - uses: emulator-wtf/configure-credentials@d0d840f8d9e2920e284788fcfa32f0a1eed95bf0 # v1.0.0
-      with:
-        oidc-configuration-id: ${{ vars.EW_OIDC_ID }}
-    - run: curl -o minimal.apk -sS https://maven.emulator.wtf/releases/wtf/emulator/minimal/0.0.2/minimal-0.0.2.apk 
-    - run: curl -o minimal-test.apk -sS https://maven.emulator.wtf/releases/wtf/emulator/minimal/0.0.2/minimal-0.0.2-test.apk 
-    - uses: ./
-      with: 
-        app: minimal.apk
-        test: minimal-test.apk
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: emulator-wtf/configure-credentials@d0d840f8d9e2920e284788fcfa32f0a1eed95bf0  # v1.0.0
+        with:
+          oidc-configuration-id: ${{ vars.EW_OIDC_ID }}
+      - run: >-
+          curl -o minimal.apk -sS
+          https://maven.emulator.wtf/releases/wtf/emulator/minimal/0.0.2/minimal-0.0.2.apk
+      - run: >-
+          curl -o minimal-test.apk -sS
+          https://maven.emulator.wtf/releases/wtf/emulator/minimal/0.0.2/minimal-0.0.2-test.apk
+      - uses: ./
+        with:
+          app: minimal.apk
+          test: minimal-test.apk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 permissions:
   contents: read
-  id-token: write
+
 on:
   pull_request:
   push:
@@ -11,6 +11,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      # required for emulator-wtf/configure-credentials to mint an OIDC token
+      id-token: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # SHA-pinned action references plus their version comment commonly
+  # exceed 80 columns and cannot be wrapped.
+  line-length:
+    max: 120

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,4 @@
+---
 name: 'Run Android instrumentation tests'
 author: 'emulator.wtf'
 description: 'Run tests with emulator.wtf'
@@ -25,10 +26,15 @@ inputs:
     description: 'Additional apks to install, one per line'
     required: false
   file-cache-ttl:
-    description: "Max time to keep cached files in the backend followed by a unit (d, h, m or s), with the maximum value being 90d and minimum value being 5m (default: 1h)"
+    description: >-
+      Max time to keep cached files in the backend followed by a unit
+      (d, h, m or s), with the maximum value being 90d and minimum value
+      being 5m (default: 1h)
     required: false
   file-cache:
-    description: "Set to false to disable remote file cache - APK and test-data will always be uploaded, even if they were uploaded before"
+    description: >-
+      Set to false to disable remote file cache - APK and test-data will
+      always be uploaded, even if they were uploaded before
     required: false
   # Test configuration
   display-name:
@@ -47,13 +53,20 @@ inputs:
     description: 'Set to true to clear app data between every test (only works with orchestrator)'
     required: false
   num-flaky-test-attempts:
-    description: "Number of times to re-run shards or jobs that had test failures. Repeat attempts will run in parallel. Default: 0."
+    description: >-
+      Number of times to re-run shards or jobs that had test failures.
+      Repeat attempts will run in parallel. Default: 0.
     required: false
   flaky-test-repeat-mode:
-    description: "Whether to repeat the whole failed shard (all) or only the failed tests (failed_only) in case of flaky tests. Default: failed_only."
+    description: >-
+      Whether to repeat the whole failed shard (all) or only the failed
+      tests (failed_only) in case of flaky tests. Default: failed_only.
     required: false
   timeout:
-    description: 'Max time until this test run is cancelled, expressed by a number followed by a unit (h, m or s), with the maximum value being 3h and minimum value being 60s (default: 15m)'
+    description: >-
+      Max time until this test run is cancelled, expressed by a number
+      followed by a unit (h, m or s), with the maximum value being 3h
+      and minimum value being 60s (default: 15m)
     required: false
   test-targets:
     description: 'Test targets to run, one operator-target per line, e.g. class foo.bar.Foobar'
@@ -62,20 +75,30 @@ inputs:
     description: 'Environment variables to pass to AndroidJUnitRunner, one per line in the form of key=value'
     required: false
   secret-environment-variables:
-    description: 'Secret environment variables to pass to AndroidJUnitRunner, one per line in the form of key=value. Use this for passing tokens, passwords, credentials, etc.'
+    description: >-
+      Secret environment variables to pass to AndroidJUnitRunner, one per
+      line in the form of key=value. Use this for passing tokens,
+      passwords, credentials, etc.
     required: false
   test-cache:
     description: "Set to false to disable remote test cache - tests will always re-run, even if they were run before"
     required: false
   side-effects:
-    description: "Indicates that the test run has side effects, i.e. it hits external resources and might be a part of a bigger test suite. Adding this flag means that the test will not be automatically retried in case of errors. Default: false."
+    description: >-
+      Indicates that the test run has side effects, i.e. it hits external
+      resources and might be a part of a bigger test suite. Adding this
+      flag means that the test will not be automatically retried in case
+      of errors. Default: false.
     required: false
   # Test sharding
   num-balanced-shards:
     description: 'Set to a number larger than 1 to split your tests into even shards based on historical runtime.'
     required: false
   shard-target-runtime:
-    description: 'Target runtime for each shard in minutes, tests will be split into shards targeting this runtime for each shard based on historical data on a best effort basis.'
+    description: >-
+      Target runtime for each shard in minutes, tests will be split into
+      shards targeting this runtime for each shard based on historical
+      data on a best effort basis.
     required: false
   num-uniform-shards:
     description: 'Set to a number larger than 1 to randomly split your tests into multiple shards.'
@@ -94,23 +117,36 @@ inputs:
     description: 'Directories to pull from device and store in <outputs-dir>, one per line'
     required: false
   outputs:
-    description: "Comma-separated list to specify what to download to output-dir. Defaults to merged_results_xml,coverage,pulled_dirs"
+    description: >-
+      Comma-separated list to specify what to download to output-dir.
+      Defaults to merged_results_xml,coverage,pulled_dirs
     required: false
   outputs-dir:
     description: 'Location to store test outputs in'
     required: false
   # Network options (emulator)
   dns-server:
-    description: 'DNS server(s) to use for the emulator, one per line. Can specify up to 4 servers. If not specified, the emulator will use default DNS servers.'
+    description: >-
+      DNS server(s) to use for the emulator, one per line. Can specify
+      up to 4 servers. If not specified, the emulator will use default
+      DNS servers.
     required: false
   dns-override:
-    description: 'Hard-code specific hostname-ip combinations, one per line in the form of hostname=ip (e.g. example.com=10.0.0.1)'
+    description: >-
+      Hard-code specific hostname-ip combinations, one per line in the
+      form of hostname=ip (e.g. example.com=10.0.0.1)
     required: false
   egress-tunnel:
-    description: 'Set to true to enable tunneling outgoing internet traffic from the emulator to the action. This will redirect all network traffic as if you were running the emulator within the action.'
+    description: >-
+      Set to true to enable tunneling outgoing internet traffic from the
+      emulator to the action. This will redirect all network traffic as
+      if you were running the emulator within the action.
     required: false
   egress-localhost-fwd-ip:
-    description: "When using the egress tunnel, make this action's localhost available to the emulator under the specified IP address (should NOT be a public IP, loopback IP or broadcast IP)"
+    description: >-
+      When using the egress tunnel, make this action's localhost
+      available to the emulator under the specified IP address (should
+      NOT be a public IP, loopback IP or broadcast IP)
     required: false
   # Network options (action)
   proxy-host:
@@ -127,7 +163,9 @@ inputs:
     required: false
   # Operation
   async:
-    description: "Run the test asynchronously, without waiting for the results. This shines when used together with GitHub integration."
+    description: >-
+      Run the test asynchronously, without waiting for the results.
+      This shines when used together with GitHub integration.
     required: false
 branding:
   color: orange
@@ -136,11 +174,11 @@ runs:
   using: composite
   steps:
     - name: Setup ew-cli
-      uses: emulator-wtf/setup-ew-cli@13b43792f7af98051e7dd29e626ec896822216b9 # v0.9.11
+      uses: emulator-wtf/setup-ew-cli@13b43792f7af98051e7dd29e626ec896822216b9  # v0.9.11
       with:
         version: ${{ inputs.version }}
     - name: Run instrumented tests
-      uses: emulator-wtf/invoke@ce6c40694d91267aaf2d03cad6cd641a6cd0917d # v0.9.8
+      uses: emulator-wtf/invoke@ce6c40694d91267aaf2d03cad6cd641a6cd0917d  # v0.9.8
       with:
         # Authentication
         api-token: ${{ inputs.api-token }}

--- a/action.yml
+++ b/action.yml
@@ -136,11 +136,11 @@ runs:
   using: composite
   steps:
     - name: Setup ew-cli
-      uses: emulator-wtf/setup-ew-cli@v0.9.11
+      uses: emulator-wtf/setup-ew-cli@13b43792f7af98051e7dd29e626ec896822216b9 # v0.9.11
       with:
         version: ${{ inputs.version }}
     - name: Run instrumented tests
-      uses: emulator-wtf/invoke@v0.9.8
+      uses: emulator-wtf/invoke@ce6c40694d91267aaf2d03cad6cd641a6cd0917d # v0.9.8
       with:
         # Authentication
         api-token: ${{ inputs.api-token }}


### PR DESCRIPTION
This PR fix the issues reported by https://github.com/zizmorcore/zizmor, the biggest one being pinning the action used, the other one is moving the permission for `id-token` closer to its usage.
I've also took the opportunity to apply yamlint to the files.