### PR TITLE
refactor: call-through to emulator-wtf/actions/run-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,21 @@ deliver quick feedback to your PRs.
 With this action you can easily run your Android instrumentation tests with
 [emulator.wtf](https://emulator.wtf).
 
+> [!WARNING]
+> The `emulator-wtf/run-tests` action has moved and is now at
+> `emulator-wtf/actions/run-tests`.
+>
+> ```patch
+> - uses: emulator-wtf/run-tests@v1
+> + uses: emulator-wtf/actions/run-tests@v1.0.0
+> ```
+>
+> We'll keep this action available as a redirect throughout the v1 series of releases.
+
 ## Quick example
 
 A really basic example building an app apk, test apk, running tests and then
-finally collecting the results with the `mikepenz/action-junit-report@v2`
+finally collecting the results with the `mikepenz/action-junit-report@v6`
 action:
 
 ```yaml
@@ -17,23 +28,27 @@ name: Run tests
 on: push
 jobs:
   run-tests:
-    runs-on: ubuntu-20.04
-  steps:
-    - uses: actions/checkout@v2
-    - name: Build app
-      run: ./gradlew assembleDebug assembleAndroidTest
-    - name: Run tests
-      uses: emulator-wtf/run-tests@v0
-      with:
-        api-token: ${{ secrets.EW_API_TOKEN }}
-        app: app/build/outputs/apk/debug/app-debug.apk
-        test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
-        outputs-dir: build/test-results
-    - name: Publish test report
-      uses: mikepenz/action-junit-report@v2
-      if: always() # always run even if the tests fail
-      with:
-        report_paths: 'build/test-results/**/*.xml'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '25'
+      - name: Build app
+        run: ./gradlew assembleDebug assembleAndroidTest
+      - name: Run tests
+        uses: emulator-wtf/actions/run-tests@v1.0.0
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
+          outputs-dir: build/test-results
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v6
+        if: always() # always run even if the tests fail
+        with:
+          report_paths: 'build/test-results/**/*.xml'
 ```
 
 ## Inputs
@@ -90,15 +105,15 @@ By default emulator.wtf runs tests on a Pixel2-like emulator with API 27
 can use the `devices` input to do so:
 
 ```yaml
-    - name: Run tests
-      uses: emulator-wtf/run-tests@v0
-      with:
-        api-token: ${{ secrets.EW_API_TOKEN }}
-        app: app/build/outputs/apk/debug/app-debug.apk
-        test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
-        devices: |
-          model=NexusLowRes,version=23
-          model=Pixel2,version=27
+      - name: Run tests
+        uses: emulator-wtf/actions/run-tests@v1.0.0
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
+          devices: |
+            model=NexusLowRes,version=23
+            model=Pixel2,version=27
 ```
 
 ### Run tests with orchestrator while clearing package data
@@ -110,14 +125,14 @@ app persisted state between each run. Read more about orchestrator
 [here](https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator).
 
 ```yaml
-    - name: Run tests
-      uses: emulator-wtf/run-tests@v0
-      with:
-        api-token: ${{ secrets.EW_API_TOKEN }}
-        app: app/build/outputs/apk/debug/app-debug.apk
-        test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
-        use-orchestrator: true
-        clear-package-data: true
+      - name: Run tests
+        uses: emulator-wtf/actions/run-tests@v1.0.0
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
+          use-orchestrator: true
+          clear-package-data: true
 ```
 
 ### Grab coverage data
@@ -127,14 +142,14 @@ results (one or more `.exec` or `.ec` files) in the path specified by
 `outputs-dir`:
 
 ```yaml
-    - name: Run tests
-      uses: emulator-wtf/run-tests@v0
-      with:
-        api-token: ${{ secrets.EW_API_TOKEN }}
-        app: app/build/outputs/apk/debug/app-debug.apk
-        test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
-        with-coverage: true
-        outputs-dir: build/test-results
+      - name: Run tests
+        uses: emulator-wtf/actions/run-tests@v1.0.0
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
+          with-coverage: true
+          outputs-dir: build/test-results
 ```
 
 
@@ -144,12 +159,12 @@ The following example runs tests in parallel using 3 separate shards and stores
 the outputs from each shard in a separate folder under `build/test-results`:
 
 ```yaml
-    - name: Run tests
-      uses: emulator-wtf/run-tests@v0
-      with:
-        api-token: ${{ secrets.EW_API_TOKEN }}
-        app: app/build/outputs/apk/debug/app-debug.apk
-        test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
-        num-shards: 3
-        outputs-dir: build/test-results
+      - name: Run tests
+        uses: emulator-wtf/actions/run-tests@v1.0.0
+        with:
+          api-token: ${{ secrets.EW_API_TOKEN }}
+          app: app/build/outputs/apk/debug/app-debug.apk
+          test: app/build/outputs/apk/androidTest/app-debug-androidTest.apk
+          num-shards: 3
+          outputs-dir: build/test-results
 ```

--- a/action.yml
+++ b/action.yml
@@ -170,13 +170,11 @@ branding:
 runs:
   using: composite
   steps:
-    - name: Setup ew-cli
-      uses: emulator-wtf/setup-ew-cli@12b25a7ce7e2cadd34d6150d8bc103cb25b68fef  # v1.0.0-rc02
-      with:
-        version: ${{ inputs.version }}
     - name: Run instrumented tests
-      uses: emulator-wtf/invoke@23e672bf91154f56e846a493e36558e5bf41cd9b  # v1.0.0-rc02
+      uses: emulator-wtf/actions/run-tests@42753a2a6bda2e657741a7385131bf61db464899  # v1.0.0
       with:
+        # ew-cli
+        version: ${{ inputs.version }}
         # Authentication
         api-token: ${{ inputs.api-token }}
         # File options


### PR DESCRIPTION
Calls through to `emulator-wtf/actions/run-tests` insetad of `emulator-wtf/setup-ew-cli` + `emulator-wtf/invoke`.
Added a warning to `README.md` and also updated the readme to mirror the one in [emulator-wtf/actions/run-tests](https://github.com/emulator-wtf/actions/tree/main/run-tests).